### PR TITLE
working through mc command example

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+"""
+Install the traversome package.
+
+Local install for developers:
+    conda install numpy pandas scipy pymc3 sympy matplotlib typer loguru -c conda-forge
+    pip install . -e --no-deps
+"""
+
 import os
 import re
 from setuptools import setup
@@ -26,6 +34,7 @@ else:
         "sympy",
         "matplotlib",
         "typer",
+        "loguru",
     ]
 
 

--- a/traversome/Assembly.py
+++ b/traversome/Assembly.py
@@ -4,19 +4,24 @@
 Assembly class object and associated class objects
 """
 
+import os
+import sys
+from copy import deepcopy
+from collections import OrderedDict
 from loguru import logger
-from traversome.AssemblySimple import AssemblySimple, VertexMergingHistory, VertexEditHistory
+from traversome.AssemblySimple import AssemblySimple #, VertexMergingHistory, VertexEditHistory
 from traversome.PathGeneratorGraphOnly import PathGeneratorGraphOnly
 from traversome.PathGeneratorGraphAlignment import PathGeneratorGraphAlignment
 from traversome.EstMultiplicityFromCov import EstMultiplicityFromCov
 from traversome.EstMultiplicityPrecise import EstMultiplicityPrecise
-from traversome.utils import \
-    Sequence, SequenceList, ProcessingGraphFailed, INF, get_orf_lengths, generate_clusters_from_connections
-    #, smart_trans_for_sort
-from copy import deepcopy
-from collections import OrderedDict
-import os
-import sys
+from traversome.utils import (
+    Sequence, SequenceList, 
+    ProcessingGraphFailed, 
+    INF, 
+    get_orf_lengths, 
+    generate_clusters_from_connections,
+    # smart_trans_for_sort,
+)
 
 
 class Assembly(AssemblySimple):
@@ -36,8 +41,10 @@ class Assembly(AssemblySimple):
         :param max_cov:
         """
         # inherit values from base class
-        super(Assembly, self).__init__(graph_file=graph_file, min_cov=min_cov, max_cov=max_cov, overlap=overlap)
-        self.__overlap = super(Assembly, self).overlap()
+        super().__init__(graph_file, min_cov, max_cov, overlap)
+        self.__overlap = self.overlap()
+        # super(Assembly, self).__init__(graph_file=graph_file, min_cov=min_cov, max_cov=max_cov, overlap=overlap)
+        # self.__overlap = super(Assembly, self).overlap()
 
         # get an initial set of clusters of connected vertices
         self.vertex_clusters = []
@@ -596,7 +603,7 @@ class Assembly(AssemblySimple):
 
     def estimate_multiplicity_precisely(
             self,
-            ave_depth,
+            # ave_depth,
             maximum_copy_num=8,
             broken_graph_allowed=False,
             return_new_graphs=False,
@@ -894,7 +901,8 @@ class Assembly(AssemblySimple):
         :param mode:
         :return: sorted_paths
         """
-        generator = PathGeneratorGraphOnly(graph=self, mode=mode).find_all_isomers()
+        generator = PathGeneratorGraphOnly(graph=self, mode=mode)
+        generator.find_all_isomers()
         return generator.components
 
     def is_circular_path(self, input_path):
@@ -907,7 +915,7 @@ class Assembly(AssemblySimple):
         return circular_len + overlap * int(self.is_circular_path(input_path))
 
     def get_path_internal_length(self, input_path):
-        assert len(input_path) > 1
+        assert len(input_path) > 1, f"input path len cannot be <= 1, this path is {input_path}"
         overlap = self.__overlap if self.__overlap else 0
         # internal_len is allowed to be negative when this_overlap > 0 and len(the_repeat_path) == 2
         internal_len = -overlap

--- a/traversome/__init__.py
+++ b/traversome/__init__.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
+"""
+Traversome long-read assembly and isomer frequency estimator
+"""
+
 __version__ = "0.0.4"
 __author__ = "JianJun Jin and Deren Eaton"
 
 
-from .traversome import Traversome
-
-
+# from .traversome import Traversome
 
 # from . import alignment_parser
 # from . import assembly_parser

--- a/traversome/traversome.py
+++ b/traversome/traversome.py
@@ -157,7 +157,10 @@ class Traversome(object):
             #     logger.error("Simultaneously using 'all' generator and 'multi-chromosome' mode is not implemented!")
             #     raise Exception
             self.graph.estimate_multiplicity_by_cov(mode="all")
-            self.graph.estimate_multiplicity_precisely(maximum_copy_num=8, debug=self.loglevel in ("DEBUG", "TRACE", "ALL"))
+            self.graph.estimate_multiplicity_precisely(
+                maximum_copy_num=8, 
+                debug=self.loglevel in ("DEBUG", "TRACE", "ALL"),
+            )
             if self.force_circular:
                 try:
                     self.component_paths = self.graph.find_all_circular_isomers(mode="all")


### PR DESCRIPTION
Hi Jianjun, 

I made a few changes, mostly to the CLI typer code, while trying to test out the mc command. Now typer checks that the files exist, and float values are in appropriate ranges. I agree that the import in __init__ can be removed to improve startup speed, since that import statement is only useful for organizing API code, and not necessary for the CLI. 

I ran into an assertion error when running the example dataset and left off there:

```bash
traversome mc -g data/data1-arabidopsis_pt.gfa -a data/data1-arabidopsis_pt.gaf
```

```bash
Traceback (most recent call last):
  File "/home/deren/miniconda3/envs/traversome/bin/traversome", line 33, in <module>
    sys.exit(load_entry_point('traversome', 'console_scripts', 'traversome')())
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/typer/main.py", line 214, in __call__
    return get_command(self)(*args, **kwargs)
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/deren/miniconda3/envs/traversome/lib/python3.7/site-packages/typer/main.py", line 497, in wrapper
    return callback(**use_params)  # type: ignore
  File "/home/deren/Documents/iFragaria/traversome/__main__.py", line 160, in mc
    multi_chromosomes=True  # opts.is_multi_chromosomes,
  File "/home/deren/Documents/iFragaria/traversome/traversome.py", line 96, in run
    multi_chromosomes=multi_chromosomes
  File "/home/deren/Documents/iFragaria/traversome/traversome.py", line 191, in generate_candidate_paths
    self.generate_isomer_sub_paths()
  File "/home/deren/Documents/iFragaria/traversome/traversome.py", line 253, in generate_isomer_sub_paths
    if self.graph.get_path_internal_length(this_longest_sub_path) < self.min_alignment_length:
  File "/home/deren/Documents/iFragaria/traversome/Assembly.py", line 918, in get_path_internal_length
    assert len(input_path) > 1, f"input path len cannot be <= 1, this path is {input_path}"
AssertionError: input path len cannot be <= 1, this path is [('2', False)]
```
